### PR TITLE
Fix typo in ESLint config README

### DIFF
--- a/packages/eslint-config-base/README.md
+++ b/packages/eslint-config-base/README.md
@@ -14,7 +14,7 @@ A package provides typescript based eslint configuration as extensible shared co
 >This configuration is for project with
 `typescript`,`eslint` and `prettier`.
 
-if you are using npm 5+, use below shortcut to install all the peer dependecies.
+if you are using npm 5+, use below shortcut to install all the peer dependencies.
 
 `npx install-peerdeps --dev @virkone/eslint-config-base`
 


### PR DESCRIPTION
## Summary
- fix typo in ESLint config documentation

## Testing
- `grep -R "dependecies" -n packages/eslint-config-base/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684513929548832cb288e76c425f3dfd